### PR TITLE
Added feature: play podcasts in terminal (Issue #7)

### DIFF
--- a/defe/__main__.py
+++ b/defe/__main__.py
@@ -128,7 +128,7 @@ def main():
                 defy(item["feed_src"], item["title"], item["link"])
             else:
                 pass
-        defy_prompt(data)
+        defy_prompt(data, podcasts=True)
     if args.feed == "feeders":
         feeds = ["general", "news", "podcasts", "newsletters"]
         print(

--- a/defe/formatter.py
+++ b/defe/formatter.py
@@ -30,8 +30,8 @@ def defy_prompt(feed, podcasts=False):
                 print(Style.RESET_ALL)
                 if podcasts:
                 	player = vlc.MediaPlayer(feed[int(feed_to_open) -1]["links"][0]["href"])
+                	print(Fore.GREEN + Style.BRIGHT + "Now playing: " + Fore.YELLOW + Style.BRIGHT + feed[int(feed_to_open)-1]["title"])
                 	player.play()
-					#VLC module throws errors very often while using; the try-except block catches them
                 	while 1:
                 		action = str(input(Fore.GREEN + Style.BRIGHT + "pause/stop [p/s] : ")).lower()
                 		if action == "p":

--- a/defe/formatter.py
+++ b/defe/formatter.py
@@ -4,6 +4,7 @@ Custom Formatter for defe
 from colorama import Fore, Style, init
 import webbrowser
 import sys
+import vlc##
 
 
 def defy(src, title, link):
@@ -13,7 +14,7 @@ def defy(src, title, link):
     print(Fore.BLUE + Style.BRIGHT + link, end="\n\n")
 
 
-def defy_prompt(feed):
+def defy_prompt(feed, podcasts=False):
     init(autoreset=True)
     while 1:
         try:
@@ -27,8 +28,24 @@ def defy_prompt(feed):
                     input(Fore.GREEN + Style.BRIGHT + "Enter Feed Index to open : ")
                 )
                 print(Style.RESET_ALL)
-                print(Style.BRIGHT + "Opening Link in your default browser ...")
-                webbrowser.open(feed[int(feed_to_open) - 1].link)
+                if podcasts:
+                	player = vlc.MediaPlayer(feed[int(feed_to_open) -1]["links"][0]["href"])
+                	player.play()
+					#VLC module throws errors very often while using; the try-except block catches them
+                	while 1:
+                		action = str(input(Fore.GREEN + Style.BRIGHT + "pause/stop [p/s] : ")).lower()
+                		if action == "p":
+                			player.pause()
+                			input(Fore.GREEN + Style.BRIGHT + "Press enter to continue : ")
+                			player.play()
+                		elif action == "s":
+                			player.stop()
+                			break
+                		else:
+                			print(Style.BRIGHT + "Please type 'p' to pause or 's' to stop the podcast")
+               	else:
+               		print(Style.BRIGHT + "Opening Link in your default browser ...")
+                	webbrowser.open(feed[int(feed_to_open) - 1].link)
         except ValueError:
             print(Style.BRIGHT + "Enter Valid Index 😟")
         except KeyboardInterrupt:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ colorama
 diskcache
 python-dotenv
 tqdm
+python-vlc


### PR DESCRIPTION
Feature like described in Issue #7 
I have used the vlc module for python to add the feature to play podcasts directly in the terminal.
When using "defe podcasts" command, the input of "Enter Feed Index to open" will start the podcast you select. You can then pause and continue or stop it.