### PR TITLE
Added feature: reload feed lookup in CLI via hotkey (Issue #14)

### DIFF
--- a/defe/__main__.py
+++ b/defe/__main__.py
@@ -102,14 +102,15 @@ def main():
         sys.exit(1)
 
     args = parser.parse_args()
-    
+
     hotkey_listener()
     set_feed(args.feed, args.max_feed_count, False)
+
 
 def set_feed(feed_arg, max_feed_count, refresh):
     if feed_arg == "general":
         data = feedcore.all_feed()
-        for item in data[: max_feed_count]:
+        for item in data[:max_feed_count]:
             print(Fore.RED + Style.BRIGHT + str(data.index(item) + 1), end=". ")
             defy(item["feed_src"], item["title"], item["link"])
         if not refresh:
@@ -118,7 +119,7 @@ def set_feed(feed_arg, max_feed_count, refresh):
             return data
     if feed_arg == "news":
         data = feedcore.news_feed()
-        for item in data[: max_feed_count]:
+        for item in data[:max_feed_count]:
             print(Fore.RED + Style.BRIGHT + str(data.index(item) + 1), end=". ")
             defy(item["feed_src"], item["title"], item["link"])
         if not refresh:
@@ -127,7 +128,7 @@ def set_feed(feed_arg, max_feed_count, refresh):
             return data
     if feed_arg == "newsletters":
         data = feedcore.newsletters_feeds()
-        for item in data[: max_feed_count]:
+        for item in data[:max_feed_count]:
             print(Fore.RED + Style.BRIGHT + str(data.index(item) + 1), end=". ")
             defy(item["feed_src"], item["title"], item["link"])
         if not refresh:
@@ -136,7 +137,7 @@ def set_feed(feed_arg, max_feed_count, refresh):
             return data
     if feed_arg == "podcasts":
         data = feedcore.podcasts_feeds()
-        for item in data[: max_feed_count]:
+        for item in data[:max_feed_count]:
             print(Fore.RED + Style.BRIGHT + str(data.index(item) + 1), end=". ")
             if item:
                 defy(item["feed_src"], item["title"], item["link"])
@@ -164,12 +165,15 @@ def set_feed(feed_arg, max_feed_count, refresh):
             Style.BRIGHT + "Open a PR at https://github.com/Bhupesh-V/defe", end="\n\n",
         )
 
+
 def on_press():
     controller = pynput.keyboard.Controller()
-    controller.type('REFRESH\n')
+    controller.type("REFRESH\n")
+
 
 def hotkey_listener():
-  keyboard.add_hotkey('alt+r', on_press)
+    keyboard.add_hotkey("alt+r", on_press)
+
 
 if __name__ == "__main__":
     main()

--- a/defe/__main__.py
+++ b/defe/__main__.py
@@ -100,36 +100,50 @@ def main():
         sys.exit(1)
 
     args = parser.parse_args()
+    
+    set_feed(args.feed, args.max_feed_count, False)
 
-    if args.feed == "general":
+def set_feed(feed_arg, max_feed_count, refresh):
+    if feed_arg == "general":
         data = feedcore.all_feed()
-        for item in data[: args.max_feed_count]:
+        for item in data[: max_feed_count]:
             print(Fore.RED + Style.BRIGHT + str(data.index(item) + 1), end=". ")
             defy(item["feed_src"], item["title"], item["link"])
-        defy_prompt(data)
-
-    if args.feed == "news":
+        if not refresh:
+            defy_prompt(data, feed_arg, max_feed_count)
+        else:
+            return data
+    if feed_arg == "news":
         data = feedcore.news_feed()
-        for item in data[: args.max_feed_count]:
+        for item in data[: max_feed_count]:
             print(Fore.RED + Style.BRIGHT + str(data.index(item) + 1), end=". ")
             defy(item["feed_src"], item["title"], item["link"])
-        defy_prompt(data)
-    if args.feed == "newsletters":
+        if not refresh:
+            defy_prompt(data, feed_arg, max_feed_count)
+        else:
+            return data
+    if feed_arg == "newsletters":
         data = feedcore.newsletters_feeds()
-        for item in data[: args.max_feed_count]:
+        for item in data[: max_feed_count]:
             print(Fore.RED + Style.BRIGHT + str(data.index(item) + 1), end=". ")
             defy(item["feed_src"], item["title"], item["link"])
-        defy_prompt(data)
-    if args.feed == "podcasts":
+        if not refresh:
+            defy_prompt(data, feed_arg, max_feed_count)
+        else:
+            return data
+    if feed_arg == "podcasts":
         data = feedcore.podcasts_feeds()
-        for item in data[: args.max_feed_count]:
+        for item in data[: max_feed_count]:
             print(Fore.RED + Style.BRIGHT + str(data.index(item) + 1), end=". ")
             if item:
                 defy(item["feed_src"], item["title"], item["link"])
             else:
                 pass
-        defy_prompt(data)
-    if args.feed == "feeders":
+        if not refresh:
+            defy_prompt(data, feed_arg, max_feed_count)
+        else:
+            return data
+    if feed_arg == "feeders":
         feeds = ["general", "news", "podcasts", "newsletters"]
         print(
             Style.BRIGHT + "\ndefe fetches feeds of these sources 😃", end="\n\n",

--- a/defe/__main__.py
+++ b/defe/__main__.py
@@ -2,6 +2,8 @@
 
 import argparse
 import sys
+import keyboard
+import pynput
 
 from colorama import Fore, Style, init
 
@@ -101,6 +103,7 @@ def main():
 
     args = parser.parse_args()
     
+    hotkey_listener()
     set_feed(args.feed, args.max_feed_count, False)
 
 def set_feed(feed_arg, max_feed_count, refresh):
@@ -161,6 +164,12 @@ def set_feed(feed_arg, max_feed_count, refresh):
             Style.BRIGHT + "Open a PR at https://github.com/Bhupesh-V/defe", end="\n\n",
         )
 
+def on_press():
+    controller = pynput.keyboard.Controller()
+    controller.type('REFRESH\n')
+
+def hotkey_listener():
+  keyboard.add_hotkey('alt+r', on_press)
 
 if __name__ == "__main__":
     main()

--- a/defe/formatter.py
+++ b/defe/formatter.py
@@ -5,7 +5,6 @@ from colorama import Fore, Style, init
 import webbrowser
 import sys
 
-
 def defy(src, title, link):
     init(autoreset=True)
     print(Style.BRIGHT + src, end="\n")
@@ -27,10 +26,16 @@ def defy_prompt(feed):
                     input(Fore.GREEN + Style.BRIGHT + "Enter Feed Index to open : ")
                 )
                 print(Style.RESET_ALL)
-                print(Style.BRIGHT + "Opening Link in your default browser ...")
-                webbrowser.open(feed[int(feed_to_open) - 1].link)
+                if 'REFRESH' not in feed_to_open:
+                    print(Style.BRIGHT + "Opening Link in your default browser ...")
+                    webbrowser.open(feed[int(feed_to_open) - 1].link)
+                else:
+                    print(chr(27) + "[2J") # clear the output
+                    feed = set_feed(feed_type, max_feed_count, True)
         except ValueError:
             print(Style.BRIGHT + "Enter Valid Index 😟")
         except KeyboardInterrupt:
             # Oh no!, come back again :(
             sys.exit()
+
+from defe.__main__ import set_feed

--- a/defe/formatter.py
+++ b/defe/formatter.py
@@ -5,6 +5,7 @@ from colorama import Fore, Style, init
 import webbrowser
 import sys
 
+
 def defy(src, title, link):
     init(autoreset=True)
     print(Style.BRIGHT + src, end="\n")
@@ -26,16 +27,17 @@ def defy_prompt(feed, feed_type, max_feed_count):
                     input(Fore.GREEN + Style.BRIGHT + "Enter Feed Index to open : ")
                 )
                 print(Style.RESET_ALL)
-                if 'REFRESH' not in feed_to_open:
+                if "REFRESH" not in feed_to_open:
                     print(Style.BRIGHT + "Opening Link in your default browser ...")
                     webbrowser.open(feed[int(feed_to_open) - 1].link)
                 else:
-                    print(chr(27) + "[2J") # clear the output
+                    print(chr(27) + "[2J")  # clear the output
                     feed = set_feed(feed_type, max_feed_count, True)
         except ValueError:
             print(Style.BRIGHT + "Enter Valid Index 😟")
         except KeyboardInterrupt:
             # Oh no!, come back again :(
             sys.exit()
+
 
 from defe.__main__ import set_feed

--- a/defe/formatter.py
+++ b/defe/formatter.py
@@ -12,7 +12,7 @@ def defy(src, title, link):
     print(Fore.BLUE + Style.BRIGHT + link, end="\n\n")
 
 
-def defy_prompt(feed):
+def defy_prompt(feed, feed_type, max_feed_count):
     init(autoreset=True)
     while 1:
         try:


### PR DESCRIPTION
Allowed refreshing the selected feed via hotkey ALT+r

**Changes**

- Added listener for hotkey combo
- Added key control to input refresh keyword on hotkey press
- Made feed fetching in main modular so it can be called on initial load or refresh
- Modified defy_prompt to take input parameters for fetching feeds