### PR TITLE
Typo fix

### DIFF
--- a/core/feeders/podcasts.json
+++ b/core/feeders/podcasts.json
@@ -91,7 +91,7 @@
             "web": "https://www.softwaredefinedtalk.com/"
         },
         {
-            "name": "Software Defined Talk",
+            "name": "Soft Skills Engineering",
             "link": "https://feeds.feedburner.com/SoftSkillsEngineering",
             "web": "https://softskills.audio/"
         },


### PR DESCRIPTION
'Software Defined Talk' was mentioned twice.
I don't know if the name of the podcast was changed but it is 'Soft Skills Engineering' now.